### PR TITLE
ccAdmin and ccAdminPasswd

### DIFF
--- a/NGF-Quickstart-HA-1NIC-AS-ELB-ILB-STD/azuredeploy.json
+++ b/NGF-Quickstart-HA-1NIC-AS-ELB-ILB-STD/azuredeploy.json
@@ -163,8 +163,8 @@
     "ngfCustomDataCCup2": "[base64(concat('#!/bin/bash\n\n', 'echo \"*/2 * * * * root echo \\\"', parameters( 'ccAdminPasswd' ), '\\\" | /opt/phion/bin/getpar -a ', parameters('ccIpAddress'), ' -r ', parameters( 'ccRangeId' ), ' -c ', parameters( 'ccClusterName' ), ' -b ', variables( 'ngfVmName2' ), ' -u ', parameters( 'ccAdmin' ), ' -d /opt/phion/update/box.par -s --verbosity 10 >> /tmp/getpar.log && /etc/rc.d/init.d/phion stop && /etc/rc.d/init.d/phion start && rm /etc/cron.d/getpar\" > /etc/cron.d/getpar\n'))]",
     "ngfCustomDataCCss1": "[base64(concat('#!/bin/bash\n\n', 'echo \"*/2 * * * * root echo \\\"', parameters( 'ccSecret' ), '\\\" | /opt/phion/bin/getpar -a ', parameters('ccIpAddress'), ' -r ', parameters( 'ccRangeId' ), ' -c ', parameters( 'ccClusterName' ), ' -b ', variables( 'ngfVmName1' ), ' -d /opt/phion/update/box.par -s --verbosity 10 >> /tmp/getpar.log && /etc/rc.d/init.d/phion stop && /etc/rc.d/init.d/phion start && rm /etc/cron.d/getpar\" > /etc/cron.d/getpar\n'))]",
     "ngfCustomDataCCss2": "[base64(concat('#!/bin/bash\n\n', 'echo \"*/2 * * * * root echo \\\"', parameters( 'ccSecret' ), '\\\" | /opt/phion/bin/getpar -a ', parameters('ccIpAddress'), ' -r ', parameters( 'ccRangeId' ), ' -c ', parameters( 'ccClusterName' ), ' -b ', variables( 'ngfVmName2' ), ' -d /opt/phion/update/box.par -s --verbosity 10 >> /tmp/getpar.log && /etc/rc.d/init.d/phion stop && /etc/rc.d/init.d/phion start && rm /etc/cron.d/getpar\" > /etc/cron.d/getpar\n'))]",
-    "ngfCustomDataCCss1": "[if( empty( parameters( 'ccAdmin' )), variables( 'ngfCustomDataCCss1' ), variables( 'ngfCustomDataCCup1' ))]",
-    "ngfCustomDataCCss2": "[if( empty( parameters( 'ccAdmin' )), variables( 'ngfCustomDataCCss2' ), variables( 'ngfCustomDataCCup2' ))]"
+    "ngfCustomDataCC1": "[if( empty( parameters( 'ccAdmin' )), variables( 'ngfCustomDataCCss1' ), variables( 'ngfCustomDataCCup1' ))]",
+    "ngfCustomDataCC2": "[if( empty( parameters( 'ccAdmin' )), variables( 'ngfCustomDataCCss2' ), variables( 'ngfCustomDataCCup2' ))]"
   },
   "resources": [
     {

--- a/NGF-Quickstart-HA-1NIC-AS-ELB-ILB-STD/azuredeploy.json
+++ b/NGF-Quickstart-HA-1NIC-AS-ELB-ILB-STD/azuredeploy.json
@@ -92,6 +92,16 @@
     "ccSecret": {
       "type": "securestring",
       "defaultValue": "only used when ccManaged set to yes"
+    },
+    "ccAdmin": {
+      "type": "string",
+      "defaultValue": "",
+      "description": "only used when ccManaged set to yes. Leave empty to use shared secret"
+    },
+    "ccAdminPasswd": {
+      "type": "securestring",
+      "defaultValue": "",
+      "description": "only used when ccManaged set to yes"
     }
   },
   "variables": {
@@ -149,8 +159,12 @@
     "ngfVmAddress2": "[concat( variables( 'ngfSubnetAddrSplit' )[0], '.', variables( 'ngfSubnetAddrSplit' )[1], '.', variables( 'ngfSubnetAddrSplit' )[2], '.', add( int( variables( 'ngfSubnetAddrSplit' )[3]), 6 ))]",
     "ngfCustomData1": "[Base64(concat( '#!/bin/bash\n\n/opb/cloud-setmip ', variables('ngfVmAddress1'), ' ', variables( 'ngfSubnetMask' ), ' ', variables( 'ngfSubnetDefaultGw' ), '\n', 'echo ', variables('singleQuotationMark'), parameters( 'adminPassword' ), variables('singleQuotationMark'), ' | /opb/create-dha -s S1 -c -o ', variables('ngfVmAddress2'), ' -n ', variables( 'ngfSubnetMask' ), ' -g ', variables( 'ngfSubnetDefaultGw' ), '\n'))]",
     "ngfCustomData2": "[Base64('\n')]",
-    "ngfCustomDataCC1": "[base64(concat('#!/bin/bash\n\n', 'echo \"*/2 * * * * root echo \\\"', parameters( 'ccSecret' ), '\\\" | /opt/phion/bin/getpar -a ', parameters('ccIpAddress'), ' -r ', parameters( 'ccRangeId' ), ' -c ', parameters( 'ccClusterName' ), ' -b ', variables( 'ngfVmName1' ), ' -d /opt/phion/update/box.par -s --verbosity 10 >> /tmp/getpar.log && /etc/rc.d/init.d/phion stop && /etc/rc.d/init.d/phion start && rm /etc/cron.d/getpar\" > /etc/cron.d/getpar\n'))]",
-    "ngfCustomDataCC2": "[base64(concat('#!/bin/bash\n\n', 'echo \"*/2 * * * * root echo \\\"', parameters( 'ccSecret' ), '\\\" | /opt/phion/bin/getpar -a ', parameters('ccIpAddress'), ' -r ', parameters( 'ccRangeId' ), ' -c ', parameters( 'ccClusterName' ), ' -b ', variables( 'ngfVmName2' ), ' -d /opt/phion/update/box.par -s --verbosity 10 >> /tmp/getpar.log && /etc/rc.d/init.d/phion stop && /etc/rc.d/init.d/phion start && rm /etc/cron.d/getpar\" > /etc/cron.d/getpar\n'))]"
+    "ngfCustomDataCCup1": "[base64(concat('#!/bin/bash\n\n', 'echo \"*/2 * * * * root echo \\\"', parameters( 'ccAdminPasswd' ), '\\\" | /opt/phion/bin/getpar -a ', parameters('ccIpAddress'), ' -r ', parameters( 'ccRangeId' ), ' -c ', parameters( 'ccClusterName' ), ' -b ', variables( 'ngfVmName1' ), ' -u ', parameters( 'ccAdmin' ), ' -d /opt/phion/update/box.par -s --verbosity 10 >> /tmp/getpar.log && /etc/rc.d/init.d/phion stop && /etc/rc.d/init.d/phion start && rm /etc/cron.d/getpar\" > /etc/cron.d/getpar\n'))]",
+    "ngfCustomDataCCup2": "[base64(concat('#!/bin/bash\n\n', 'echo \"*/2 * * * * root echo \\\"', parameters( 'ccAdminPasswd' ), '\\\" | /opt/phion/bin/getpar -a ', parameters('ccIpAddress'), ' -r ', parameters( 'ccRangeId' ), ' -c ', parameters( 'ccClusterName' ), ' -b ', variables( 'ngfVmName2' ), ' -u ', parameters( 'ccAdmin' ), ' -d /opt/phion/update/box.par -s --verbosity 10 >> /tmp/getpar.log && /etc/rc.d/init.d/phion stop && /etc/rc.d/init.d/phion start && rm /etc/cron.d/getpar\" > /etc/cron.d/getpar\n'))]",
+    "ngfCustomDataCCss1": "[base64(concat('#!/bin/bash\n\n', 'echo \"*/2 * * * * root echo \\\"', parameters( 'ccSecret' ), '\\\" | /opt/phion/bin/getpar -a ', parameters('ccIpAddress'), ' -r ', parameters( 'ccRangeId' ), ' -c ', parameters( 'ccClusterName' ), ' -b ', variables( 'ngfVmName1' ), ' -d /opt/phion/update/box.par -s --verbosity 10 >> /tmp/getpar.log && /etc/rc.d/init.d/phion stop && /etc/rc.d/init.d/phion start && rm /etc/cron.d/getpar\" > /etc/cron.d/getpar\n'))]",
+    "ngfCustomDataCCss2": "[base64(concat('#!/bin/bash\n\n', 'echo \"*/2 * * * * root echo \\\"', parameters( 'ccSecret' ), '\\\" | /opt/phion/bin/getpar -a ', parameters('ccIpAddress'), ' -r ', parameters( 'ccRangeId' ), ' -c ', parameters( 'ccClusterName' ), ' -b ', variables( 'ngfVmName2' ), ' -d /opt/phion/update/box.par -s --verbosity 10 >> /tmp/getpar.log && /etc/rc.d/init.d/phion stop && /etc/rc.d/init.d/phion start && rm /etc/cron.d/getpar\" > /etc/cron.d/getpar\n'))]",
+    "ngfCustomDataCCss1": "[if( empty( parameters( 'ccAdmin' )), variables( 'ngfCustomDataCCss1' ), variables( 'ngfCustomDataCCup1' ))]",
+    "ngfCustomDataCCss2": "[if( empty( parameters( 'ccAdmin' )), variables( 'ngfCustomDataCCss2' ), variables( 'ngfCustomDataCCup2' ))]"
   },
   "resources": [
     {
@@ -298,7 +312,7 @@
       "dependsOn": [],
       "properties": {
           "platformFaultDomainCount": 2,
-          "platformUpdateDomainCount": 5                
+          "platformUpdateDomainCount": 5
       },
       "sku": {
         "name": "Aligned"

--- a/NGF-Quickstart-HA-1NIC-AS-ELB-ILB-STD/azuredeploy.parameters.json
+++ b/NGF-Quickstart-HA-1NIC-AS-ELB-ILB-STD/azuredeploy.parameters.json
@@ -40,6 +40,12 @@
     },
     "ccSecret": {
       "value": ""
+    },
+    "ccAdmin": {
+      "value": ""
+    },
+    "ccAdminPasswd": {
+      "value": ""
     }
   }
 }


### PR DESCRIPTION
are used now instead of ccSecret if ccAdmin is not empty (required for CC-managed PAYG instances before 7.2.1)